### PR TITLE
카카오톡 전송 기능 추가

### DIFF
--- a/django_monitoring/dbdump.json
+++ b/django_monitoring/dbdump.json
@@ -109,7 +109,7 @@
     "model": "mainpage.regionlarge",
     "pk": 1,
     "fields": {
-        "name": "ÀüÃ¼¼±ÅÃ",
+        "name": "ì „ì²´ì„ íƒ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -120,7 +120,7 @@
     "model": "mainpage.regionlarge",
     "pk": 2,
     "fields": {
-        "name": "¼­¿ïÆ¯º°½Ã",
+        "name": "ì„œìš¸íŠ¹ë³„ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -131,7 +131,7 @@
     "model": "mainpage.regionlarge",
     "pk": 3,
     "fields": {
-        "name": "ºÎ»ê±¤¿ª½Ã",
+        "name": "ë¶€ì‚°ê´‘ì—­ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -142,7 +142,7 @@
     "model": "mainpage.regionlarge",
     "pk": 4,
     "fields": {
-        "name": "´ë±¸±¤¿ª½Ã",
+        "name": "ëŒ€êµ¬ê´‘ì—­ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -153,7 +153,7 @@
     "model": "mainpage.regionlarge",
     "pk": 5,
     "fields": {
-        "name": "±¤ÁÖ±¤¿ª½Ã",
+        "name": "ê´‘ì£¼ê´‘ì—­ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -164,7 +164,7 @@
     "model": "mainpage.regionlarge",
     "pk": 6,
     "fields": {
-        "name": "ÀÎÃµ±¤¿ª½Ã",
+        "name": "ì¸ì²œê´‘ì—­ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -175,7 +175,7 @@
     "model": "mainpage.regionlarge",
     "pk": 7,
     "fields": {
-        "name": "´ëÀü±¤¿ª½Ã",
+        "name": "ëŒ€ì „ê´‘ì—­ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -186,7 +186,7 @@
     "model": "mainpage.regionlarge",
     "pk": 8,
     "fields": {
-        "name": "¿ï»ê±¤¿ª½Ã",
+        "name": "ìš¸ì‚°ê´‘ì—­ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -197,7 +197,7 @@
     "model": "mainpage.regionlarge",
     "pk": 9,
     "fields": {
-        "name": "¼¼Á¾Æ¯º°ÀÚÄ¡½Ã",
+        "name": "ì„¸ì¢…íŠ¹ë³„ìì¹˜ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -208,7 +208,7 @@
     "model": "mainpage.regionlarge",
     "pk": 10,
     "fields": {
-        "name": "°æ±âµµ",
+        "name": "ê²½ê¸°ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -219,7 +219,7 @@
     "model": "mainpage.regionlarge",
     "pk": 11,
     "fields": {
-        "name": "°­¿øµµ",
+        "name": "ê°•ì›ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -230,7 +230,7 @@
     "model": "mainpage.regionlarge",
     "pk": 12,
     "fields": {
-        "name": "ÃæÃ»ºÏµµ",
+        "name": "ì¶©ì²­ë¶ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -241,7 +241,7 @@
     "model": "mainpage.regionlarge",
     "pk": 13,
     "fields": {
-        "name": "ÃæÃ»³²µµ",
+        "name": "ì¶©ì²­ë‚¨ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -252,7 +252,7 @@
     "model": "mainpage.regionlarge",
     "pk": 14,
     "fields": {
-        "name": "Àü¶óºÏµµ",
+        "name": "ì „ë¼ë¶ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -263,7 +263,7 @@
     "model": "mainpage.regionlarge",
     "pk": 15,
     "fields": {
-        "name": "Àü¶ó³²µµ",
+        "name": "ì „ë¼ë‚¨ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -274,7 +274,7 @@
     "model": "mainpage.regionlarge",
     "pk": 16,
     "fields": {
-        "name": "°æ»óºÏµµ",
+        "name": "ê²½ìƒë¶ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -285,7 +285,7 @@
     "model": "mainpage.regionlarge",
     "pk": 17,
     "fields": {
-        "name": "°æ»ó³²µµ",
+        "name": "ê²½ìƒë‚¨ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -296,7 +296,7 @@
     "model": "mainpage.regionlarge",
     "pk": 18,
     "fields": {
-        "name": "Á¦ÁÖÆ¯º°ÀÚÄ¡µµ",
+        "name": "ì œì£¼íŠ¹ë³„ìì¹˜ë„",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -307,7 +307,7 @@
     "model": "mainpage.regionlarge",
     "pk": 19,
     "fields": {
-        "name": "ÇØ¿ÜÀ¯ÀÔ",
+        "name": "í•´ì™¸ìœ ì…",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -318,7 +318,7 @@
     "model": "mainpage.regionmedium",
     "pk": 1,
     "fields": {
-        "name": "Á¾·Î±¸",
+        "name": "ì¢…ë¡œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -330,7 +330,7 @@
     "model": "mainpage.regionmedium",
     "pk": 2,
     "fields": {
-        "name": "Áß±¸",
+        "name": "ì¤‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -342,7 +342,7 @@
     "model": "mainpage.regionmedium",
     "pk": 3,
     "fields": {
-        "name": "¿ë»ê±¸",
+        "name": "ìš©ì‚°êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -354,7 +354,7 @@
     "model": "mainpage.regionmedium",
     "pk": 4,
     "fields": {
-        "name": "¼ºµ¿±¸",
+        "name": "ì„±ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -366,7 +366,7 @@
     "model": "mainpage.regionmedium",
     "pk": 5,
     "fields": {
-        "name": "±¤Áø±¸",
+        "name": "ê´‘ì§„êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -378,7 +378,7 @@
     "model": "mainpage.regionmedium",
     "pk": 6,
     "fields": {
-        "name": "µ¿´ë¹®±¸",
+        "name": "ë™ëŒ€ë¬¸êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -390,7 +390,7 @@
     "model": "mainpage.regionmedium",
     "pk": 7,
     "fields": {
-        "name": "Áß¶û±¸",
+        "name": "ì¤‘ë‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -402,7 +402,7 @@
     "model": "mainpage.regionmedium",
     "pk": 8,
     "fields": {
-        "name": "¼ººÏ±¸",
+        "name": "ì„±ë¶êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -414,7 +414,7 @@
     "model": "mainpage.regionmedium",
     "pk": 9,
     "fields": {
-        "name": "°­ºÏ±¸",
+        "name": "ê°•ë¶êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -426,7 +426,7 @@
     "model": "mainpage.regionmedium",
     "pk": 10,
     "fields": {
-        "name": "µµºÀ±¸",
+        "name": "ë„ë´‰êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -438,7 +438,7 @@
     "model": "mainpage.regionmedium",
     "pk": 11,
     "fields": {
-        "name": "³ë¿ø±¸",
+        "name": "ë…¸ì›êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -450,7 +450,7 @@
     "model": "mainpage.regionmedium",
     "pk": 12,
     "fields": {
-        "name": "ÀºÆò±¸",
+        "name": "ì€í‰êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -462,7 +462,7 @@
     "model": "mainpage.regionmedium",
     "pk": 13,
     "fields": {
-        "name": "¼­´ë¹®±¸",
+        "name": "ì„œëŒ€ë¬¸êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -474,7 +474,7 @@
     "model": "mainpage.regionmedium",
     "pk": 14,
     "fields": {
-        "name": "¸¶Æ÷±¸",
+        "name": "ë§ˆí¬êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -486,7 +486,7 @@
     "model": "mainpage.regionmedium",
     "pk": 15,
     "fields": {
-        "name": "¾çÃµ±¸",
+        "name": "ì–‘ì²œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -498,7 +498,7 @@
     "model": "mainpage.regionmedium",
     "pk": 16,
     "fields": {
-        "name": "°­¼­±¸",
+        "name": "ê°•ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -510,7 +510,7 @@
     "model": "mainpage.regionmedium",
     "pk": 17,
     "fields": {
-        "name": "±¸·Î±¸",
+        "name": "êµ¬ë¡œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -522,7 +522,7 @@
     "model": "mainpage.regionmedium",
     "pk": 18,
     "fields": {
-        "name": "±İÃµ±¸",
+        "name": "ê¸ˆì²œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -534,7 +534,7 @@
     "model": "mainpage.regionmedium",
     "pk": 19,
     "fields": {
-        "name": "¿µµîÆ÷±¸",
+        "name": "ì˜ë“±í¬êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -546,7 +546,7 @@
     "model": "mainpage.regionmedium",
     "pk": 20,
     "fields": {
-        "name": "µ¿ÀÛ±¸",
+        "name": "ë™ì‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -558,7 +558,7 @@
     "model": "mainpage.regionmedium",
     "pk": 21,
     "fields": {
-        "name": "°ü¾Ç±¸",
+        "name": "ê´€ì•…êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -570,7 +570,7 @@
     "model": "mainpage.regionmedium",
     "pk": 22,
     "fields": {
-        "name": "¼­ÃÊ±¸",
+        "name": "ì„œì´ˆêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -582,7 +582,7 @@
     "model": "mainpage.regionmedium",
     "pk": 23,
     "fields": {
-        "name": "°­³²±¸",
+        "name": "ê°•ë‚¨êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -594,7 +594,7 @@
     "model": "mainpage.regionmedium",
     "pk": 24,
     "fields": {
-        "name": "¼ÛÆÄ±¸",
+        "name": "ì†¡íŒŒêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -606,7 +606,7 @@
     "model": "mainpage.regionmedium",
     "pk": 25,
     "fields": {
-        "name": "°­µ¿±¸",
+        "name": "ê°•ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -618,7 +618,7 @@
     "model": "mainpage.regionmedium",
     "pk": 26,
     "fields": {
-        "name": "Áß±¸",
+        "name": "ì¤‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -630,7 +630,7 @@
     "model": "mainpage.regionmedium",
     "pk": 27,
     "fields": {
-        "name": "¼­±¸",
+        "name": "ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -642,7 +642,7 @@
     "model": "mainpage.regionmedium",
     "pk": 28,
     "fields": {
-        "name": "µ¿±¸",
+        "name": "ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -654,7 +654,7 @@
     "model": "mainpage.regionmedium",
     "pk": 29,
     "fields": {
-        "name": "¿µµµ±¸",
+        "name": "ì˜ë„êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -666,7 +666,7 @@
     "model": "mainpage.regionmedium",
     "pk": 30,
     "fields": {
-        "name": "ºÎ»êÁø±¸",
+        "name": "ë¶€ì‚°ì§„êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -678,7 +678,7 @@
     "model": "mainpage.regionmedium",
     "pk": 31,
     "fields": {
-        "name": "µ¿·¡±¸",
+        "name": "ë™ë˜êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -690,7 +690,7 @@
     "model": "mainpage.regionmedium",
     "pk": 32,
     "fields": {
-        "name": "³²±¸",
+        "name": "ë‚¨êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -702,7 +702,7 @@
     "model": "mainpage.regionmedium",
     "pk": 33,
     "fields": {
-        "name": "ºÏ±¸",
+        "name": "ë¶êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -714,7 +714,7 @@
     "model": "mainpage.regionmedium",
     "pk": 34,
     "fields": {
-        "name": "°­¼­±¸",
+        "name": "ê°•ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -726,7 +726,7 @@
     "model": "mainpage.regionmedium",
     "pk": 35,
     "fields": {
-        "name": "ÇØ¿î´ë±¸",
+        "name": "í•´ìš´ëŒ€êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -738,7 +738,7 @@
     "model": "mainpage.regionmedium",
     "pk": 36,
     "fields": {
-        "name": "»çÇÏ±¸",
+        "name": "ì‚¬í•˜êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -750,7 +750,7 @@
     "model": "mainpage.regionmedium",
     "pk": 37,
     "fields": {
-        "name": "±İÁ¤±¸",
+        "name": "ê¸ˆì •êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -762,7 +762,7 @@
     "model": "mainpage.regionmedium",
     "pk": 38,
     "fields": {
-        "name": "¿¬Á¦±¸",
+        "name": "ì—°ì œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -774,7 +774,7 @@
     "model": "mainpage.regionmedium",
     "pk": 39,
     "fields": {
-        "name": "¼ö¿µ±¸",
+        "name": "ìˆ˜ì˜êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -786,7 +786,7 @@
     "model": "mainpage.regionmedium",
     "pk": 40,
     "fields": {
-        "name": "»ç»ó±¸",
+        "name": "ì‚¬ìƒêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -798,7 +798,7 @@
     "model": "mainpage.regionmedium",
     "pk": 41,
     "fields": {
-        "name": "±âÀå±º",
+        "name": "ê¸°ì¥êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -810,7 +810,7 @@
     "model": "mainpage.regionmedium",
     "pk": 42,
     "fields": {
-        "name": "Áß±¸",
+        "name": "ì¤‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -822,7 +822,7 @@
     "model": "mainpage.regionmedium",
     "pk": 43,
     "fields": {
-        "name": "µ¿±¸",
+        "name": "ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -834,7 +834,7 @@
     "model": "mainpage.regionmedium",
     "pk": 44,
     "fields": {
-        "name": "¼­±¸",
+        "name": "ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -846,7 +846,7 @@
     "model": "mainpage.regionmedium",
     "pk": 45,
     "fields": {
-        "name": "³²±¸",
+        "name": "ë‚¨êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -858,7 +858,7 @@
     "model": "mainpage.regionmedium",
     "pk": 46,
     "fields": {
-        "name": "ºÏ±¸",
+        "name": "ë¶êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -870,7 +870,7 @@
     "model": "mainpage.regionmedium",
     "pk": 47,
     "fields": {
-        "name": "¼ö¼º±¸",
+        "name": "ìˆ˜ì„±êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -882,7 +882,7 @@
     "model": "mainpage.regionmedium",
     "pk": 48,
     "fields": {
-        "name": "´Ş¼­±¸",
+        "name": "ë‹¬ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -894,7 +894,7 @@
     "model": "mainpage.regionmedium",
     "pk": 49,
     "fields": {
-        "name": "´Ş¼º±º",
+        "name": "ë‹¬ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -906,7 +906,7 @@
     "model": "mainpage.regionmedium",
     "pk": 50,
     "fields": {
-        "name": "µ¿±¸",
+        "name": "ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -918,7 +918,7 @@
     "model": "mainpage.regionmedium",
     "pk": 51,
     "fields": {
-        "name": "¼­±¸",
+        "name": "ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -930,7 +930,7 @@
     "model": "mainpage.regionmedium",
     "pk": 52,
     "fields": {
-        "name": "³²±¸",
+        "name": "ë‚¨êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -942,7 +942,7 @@
     "model": "mainpage.regionmedium",
     "pk": 53,
     "fields": {
-        "name": "ºÏ±¸",
+        "name": "ë¶êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -954,7 +954,7 @@
     "model": "mainpage.regionmedium",
     "pk": 54,
     "fields": {
-        "name": "±¤»ê±¸",
+        "name": "ê´‘ì‚°êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -966,7 +966,7 @@
     "model": "mainpage.regionmedium",
     "pk": 55,
     "fields": {
-        "name": "Áß±¸",
+        "name": "ì¤‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -978,7 +978,7 @@
     "model": "mainpage.regionmedium",
     "pk": 56,
     "fields": {
-        "name": "µ¿±¸",
+        "name": "ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -990,7 +990,7 @@
     "model": "mainpage.regionmedium",
     "pk": 57,
     "fields": {
-        "name": "¹ÌÃßÈ¦±¸",
+        "name": "ë¯¸ì¶”í™€êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1002,7 +1002,7 @@
     "model": "mainpage.regionmedium",
     "pk": 58,
     "fields": {
-        "name": "¿¬¼ö±¸",
+        "name": "ì—°ìˆ˜êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1014,7 +1014,7 @@
     "model": "mainpage.regionmedium",
     "pk": 59,
     "fields": {
-        "name": "³²µ¿±¸",
+        "name": "ë‚¨ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1026,7 +1026,7 @@
     "model": "mainpage.regionmedium",
     "pk": 60,
     "fields": {
-        "name": "ºÎÆò±¸",
+        "name": "ë¶€í‰êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1038,7 +1038,7 @@
     "model": "mainpage.regionmedium",
     "pk": 61,
     "fields": {
-        "name": "°è¾ç±¸",
+        "name": "ê³„ì–‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1050,7 +1050,7 @@
     "model": "mainpage.regionmedium",
     "pk": 62,
     "fields": {
-        "name": "¼­±¸",
+        "name": "ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1062,7 +1062,7 @@
     "model": "mainpage.regionmedium",
     "pk": 63,
     "fields": {
-        "name": "°­È­±º",
+        "name": "ê°•í™”êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1074,7 +1074,7 @@
     "model": "mainpage.regionmedium",
     "pk": 64,
     "fields": {
-        "name": "¿ËÁø±º",
+        "name": "ì˜¹ì§„êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1086,7 +1086,7 @@
     "model": "mainpage.regionmedium",
     "pk": 65,
     "fields": {
-        "name": "µ¿±¸",
+        "name": "ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1098,7 +1098,7 @@
     "model": "mainpage.regionmedium",
     "pk": 66,
     "fields": {
-        "name": "Áß±¸",
+        "name": "ì¤‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1110,7 +1110,7 @@
     "model": "mainpage.regionmedium",
     "pk": 67,
     "fields": {
-        "name": "¼­±¸",
+        "name": "ì„œêµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1122,7 +1122,7 @@
     "model": "mainpage.regionmedium",
     "pk": 68,
     "fields": {
-        "name": "À¯¼º±¸",
+        "name": "ìœ ì„±êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1134,7 +1134,7 @@
     "model": "mainpage.regionmedium",
     "pk": 69,
     "fields": {
-        "name": "´ë´ö±¸",
+        "name": "ëŒ€ë•êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1146,7 +1146,7 @@
     "model": "mainpage.regionmedium",
     "pk": 70,
     "fields": {
-        "name": "Áß±¸",
+        "name": "ì¤‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1158,7 +1158,7 @@
     "model": "mainpage.regionmedium",
     "pk": 71,
     "fields": {
-        "name": "³²±¸",
+        "name": "ë‚¨êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1170,7 +1170,7 @@
     "model": "mainpage.regionmedium",
     "pk": 72,
     "fields": {
-        "name": "µ¿±¸",
+        "name": "ë™êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1182,7 +1182,7 @@
     "model": "mainpage.regionmedium",
     "pk": 73,
     "fields": {
-        "name": "ºÏ±¸",
+        "name": "ë¶êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1194,7 +1194,7 @@
     "model": "mainpage.regionmedium",
     "pk": 74,
     "fields": {
-        "name": "¿ïÁÖ±º",
+        "name": "ìš¸ì£¼êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1206,7 +1206,7 @@
     "model": "mainpage.regionmedium",
     "pk": 75,
     "fields": {
-        "name": "Áß±¸",
+        "name": "ì¤‘êµ¬",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1218,7 +1218,7 @@
     "model": "mainpage.regionmedium",
     "pk": 76,
     "fields": {
-        "name": "Á¶Ä¡¿øÀ¾",
+        "name": "ì¡°ì¹˜ì›ì",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1230,7 +1230,7 @@
     "model": "mainpage.regionmedium",
     "pk": 77,
     "fields": {
-        "name": "±İ³²¸é",
+        "name": "ê¸ˆë‚¨ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1242,7 +1242,7 @@
     "model": "mainpage.regionmedium",
     "pk": 78,
     "fields": {
-        "name": "ºÎ°­¸é",
+        "name": "ë¶€ê°•ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1254,7 +1254,7 @@
     "model": "mainpage.regionmedium",
     "pk": 79,
     "fields": {
-        "name": "¼ÒÁ¤¸é",
+        "name": "ì†Œì •ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1266,7 +1266,7 @@
     "model": "mainpage.regionmedium",
     "pk": 80,
     "fields": {
-        "name": "¿¬±â¸é",
+        "name": "ì—°ê¸°ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1278,7 +1278,7 @@
     "model": "mainpage.regionmedium",
     "pk": 81,
     "fields": {
-        "name": "¿¬µ¿¸é",
+        "name": "ì—°ë™ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1290,7 +1290,7 @@
     "model": "mainpage.regionmedium",
     "pk": 82,
     "fields": {
-        "name": "¿¬¼­¸é",
+        "name": "ì—°ì„œë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1302,7 +1302,7 @@
     "model": "mainpage.regionmedium",
     "pk": 83,
     "fields": {
-        "name": "Àå±º¸é",
+        "name": "ì¥êµ°ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1314,7 +1314,7 @@
     "model": "mainpage.regionmedium",
     "pk": 84,
     "fields": {
-        "name": "Àüµ¿¸é",
+        "name": "ì „ë™ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1326,7 +1326,7 @@
     "model": "mainpage.regionmedium",
     "pk": 85,
     "fields": {
-        "name": "ÀüÀÇ¸é",
+        "name": "ì „ì˜ë©´",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1338,7 +1338,7 @@
     "model": "mainpage.regionmedium",
     "pk": 86,
     "fields": {
-        "name": "°í¿îµ¿",
+        "name": "ê³ ìš´ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1350,7 +1350,7 @@
     "model": "mainpage.regionmedium",
     "pk": 87,
     "fields": {
-        "name": "´ÙÁ¤µ¿",
+        "name": "ë‹¤ì •ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1362,7 +1362,7 @@
     "model": "mainpage.regionmedium",
     "pk": 88,
     "fields": {
-        "name": "´ëÆòµ¿",
+        "name": "ëŒ€í‰ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1374,7 +1374,7 @@
     "model": "mainpage.regionmedium",
     "pk": 89,
     "fields": {
-        "name": "µµ´ãµ¿",
+        "name": "ë„ë‹´ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1386,7 +1386,7 @@
     "model": "mainpage.regionmedium",
     "pk": 90,
     "fields": {
-        "name": "º¸¶÷µ¿",
+        "name": "ë³´ëŒë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1398,7 +1398,7 @@
     "model": "mainpage.regionmedium",
     "pk": 91,
     "fields": {
-        "name": "¼Ò´ãµ¿",
+        "name": "ì†Œë‹´ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1410,7 +1410,7 @@
     "model": "mainpage.regionmedium",
     "pk": 92,
     "fields": {
-        "name": "»õ·Òµ¿",
+        "name": "ìƒˆë¡¬ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1422,7 +1422,7 @@
     "model": "mainpage.regionmedium",
     "pk": 93,
     "fields": {
-        "name": "¾Æ¸§µ¿",
+        "name": "ì•„ë¦„ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1434,7 +1434,7 @@
     "model": "mainpage.regionmedium",
     "pk": 94,
     "fields": {
-        "name": "Á¾ÃÌµ¿",
+        "name": "ì¢…ì´Œë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1446,7 +1446,7 @@
     "model": "mainpage.regionmedium",
     "pk": 95,
     "fields": {
-        "name": "ÇÑ¼Öµ¿",
+        "name": "í•œì†”ë™",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1458,7 +1458,7 @@
     "model": "mainpage.regionmedium",
     "pk": 96,
     "fields": {
-        "name": "¼ö¿ø½Ã",
+        "name": "ìˆ˜ì›ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1470,7 +1470,7 @@
     "model": "mainpage.regionmedium",
     "pk": 97,
     "fields": {
-        "name": "¼º³²½Ã",
+        "name": "ì„±ë‚¨ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1482,7 +1482,7 @@
     "model": "mainpage.regionmedium",
     "pk": 98,
     "fields": {
-        "name": "¾È¾ç½Ã",
+        "name": "ì•ˆì–‘ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1494,7 +1494,7 @@
     "model": "mainpage.regionmedium",
     "pk": 99,
     "fields": {
-        "name": "¾È»ê½Ã",
+        "name": "ì•ˆì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1506,7 +1506,7 @@
     "model": "mainpage.regionmedium",
     "pk": 100,
     "fields": {
-        "name": "¿ëÀÎ½Ã",
+        "name": "ìš©ì¸ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1518,7 +1518,7 @@
     "model": "mainpage.regionmedium",
     "pk": 101,
     "fields": {
-        "name": "ºÎÃµ½Ã",
+        "name": "ë¶€ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1530,7 +1530,7 @@
     "model": "mainpage.regionmedium",
     "pk": 102,
     "fields": {
-        "name": "±¤¸í½Ã",
+        "name": "ê´‘ëª…ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1542,7 +1542,7 @@
     "model": "mainpage.regionmedium",
     "pk": 103,
     "fields": {
-        "name": "ÆòÅÃ½Ã",
+        "name": "í‰íƒì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1554,7 +1554,7 @@
     "model": "mainpage.regionmedium",
     "pk": 104,
     "fields": {
-        "name": "°úÃµ½Ã",
+        "name": "ê³¼ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1566,7 +1566,7 @@
     "model": "mainpage.regionmedium",
     "pk": 105,
     "fields": {
-        "name": "¿À»ê½Ã",
+        "name": "ì˜¤ì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1578,7 +1578,7 @@
     "model": "mainpage.regionmedium",
     "pk": 106,
     "fields": {
-        "name": "½ÃÈï½Ã",
+        "name": "ì‹œí¥ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1590,7 +1590,7 @@
     "model": "mainpage.regionmedium",
     "pk": 107,
     "fields": {
-        "name": "±ºÆ÷½Ã",
+        "name": "êµ°í¬ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1602,7 +1602,7 @@
     "model": "mainpage.regionmedium",
     "pk": 108,
     "fields": {
-        "name": "ÀÇ¿Õ½Ã",
+        "name": "ì˜ì™•ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1614,7 +1614,7 @@
     "model": "mainpage.regionmedium",
     "pk": 109,
     "fields": {
-        "name": "ÇÏ³²½Ã",
+        "name": "í•˜ë‚¨ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1626,7 +1626,7 @@
     "model": "mainpage.regionmedium",
     "pk": 110,
     "fields": {
-        "name": "ÀÌÃµ½Ã",
+        "name": "ì´ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1638,7 +1638,7 @@
     "model": "mainpage.regionmedium",
     "pk": 111,
     "fields": {
-        "name": "È­¼º½Ã",
+        "name": "í™”ì„±ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1650,7 +1650,7 @@
     "model": "mainpage.regionmedium",
     "pk": 112,
     "fields": {
-        "name": "±¤ÁÖ½Ã",
+        "name": "ê´‘ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1662,7 +1662,7 @@
     "model": "mainpage.regionmedium",
     "pk": 113,
     "fields": {
-        "name": "¿©ÁÖ½Ã",
+        "name": "ì—¬ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1674,7 +1674,7 @@
     "model": "mainpage.regionmedium",
     "pk": 114,
     "fields": {
-        "name": "¾çÆò±º",
+        "name": "ì–‘í‰êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1686,7 +1686,7 @@
     "model": "mainpage.regionmedium",
     "pk": 115,
     "fields": {
-        "name": "°í¾ç½Ã",
+        "name": "ê³ ì–‘ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1698,7 +1698,7 @@
     "model": "mainpage.regionmedium",
     "pk": 116,
     "fields": {
-        "name": "ÀÇÁ¤ºÎ½Ã",
+        "name": "ì˜ì •ë¶€ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1710,7 +1710,7 @@
     "model": "mainpage.regionmedium",
     "pk": 117,
     "fields": {
-        "name": "µ¿µÎÃµ½Ã",
+        "name": "ë™ë‘ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1722,7 +1722,7 @@
     "model": "mainpage.regionmedium",
     "pk": 118,
     "fields": {
-        "name": "±¸¸®½Ã",
+        "name": "êµ¬ë¦¬ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1734,7 +1734,7 @@
     "model": "mainpage.regionmedium",
     "pk": 119,
     "fields": {
-        "name": "³²¾çÁÖ½Ã",
+        "name": "ë‚¨ì–‘ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1746,7 +1746,7 @@
     "model": "mainpage.regionmedium",
     "pk": 120,
     "fields": {
-        "name": "ÆÄÁÖ½Ã",
+        "name": "íŒŒì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1758,7 +1758,7 @@
     "model": "mainpage.regionmedium",
     "pk": 121,
     "fields": {
-        "name": "¾çÁÖ½Ã",
+        "name": "ì–‘ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1770,7 +1770,7 @@
     "model": "mainpage.regionmedium",
     "pk": 122,
     "fields": {
-        "name": "Æ÷Ãµ½Ã",
+        "name": "í¬ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1782,7 +1782,7 @@
     "model": "mainpage.regionmedium",
     "pk": 123,
     "fields": {
-        "name": "¿¬Ãµ±º",
+        "name": "ì—°ì²œêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1794,7 +1794,7 @@
     "model": "mainpage.regionmedium",
     "pk": 124,
     "fields": {
-        "name": "°¡Æò±º",
+        "name": "ê°€í‰êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1806,7 +1806,7 @@
     "model": "mainpage.regionmedium",
     "pk": 125,
     "fields": {
-        "name": "ÃáÃµ½Ã",
+        "name": "ì¶˜ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1818,7 +1818,7 @@
     "model": "mainpage.regionmedium",
     "pk": 126,
     "fields": {
-        "name": "¿øÁÖ½Ã",
+        "name": "ì›ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1830,7 +1830,7 @@
     "model": "mainpage.regionmedium",
     "pk": 127,
     "fields": {
-        "name": "°­¸ª½Ã",
+        "name": "ê°•ë¦‰ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1842,7 +1842,7 @@
     "model": "mainpage.regionmedium",
     "pk": 128,
     "fields": {
-        "name": "µ¿ÇØ½Ã",
+        "name": "ë™í•´ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1854,7 +1854,7 @@
     "model": "mainpage.regionmedium",
     "pk": 129,
     "fields": {
-        "name": "ÅÂ¹é½Ã",
+        "name": "íƒœë°±ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1866,7 +1866,7 @@
     "model": "mainpage.regionmedium",
     "pk": 130,
     "fields": {
-        "name": "¼ÓÃÊ½Ã",
+        "name": "ì†ì´ˆì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1878,7 +1878,7 @@
     "model": "mainpage.regionmedium",
     "pk": 131,
     "fields": {
-        "name": "»ïÃ´½Ã",
+        "name": "ì‚¼ì²™ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1890,7 +1890,7 @@
     "model": "mainpage.regionmedium",
     "pk": 132,
     "fields": {
-        "name": "È«Ã»±º",
+        "name": "í™ì²­êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1902,7 +1902,7 @@
     "model": "mainpage.regionmedium",
     "pk": 133,
     "fields": {
-        "name": "È¾¼º±º",
+        "name": "íš¡ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1914,7 +1914,7 @@
     "model": "mainpage.regionmedium",
     "pk": 134,
     "fields": {
-        "name": "¿µ¿ù±º",
+        "name": "ì˜ì›”êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1926,7 +1926,7 @@
     "model": "mainpage.regionmedium",
     "pk": 135,
     "fields": {
-        "name": "ÆòÃ¢±º",
+        "name": "í‰ì°½êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1938,7 +1938,7 @@
     "model": "mainpage.regionmedium",
     "pk": 136,
     "fields": {
-        "name": "Á¤¼±±º",
+        "name": "ì •ì„ êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1950,7 +1950,7 @@
     "model": "mainpage.regionmedium",
     "pk": 137,
     "fields": {
-        "name": "Ã¶¿ø±º",
+        "name": "ì² ì›êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1962,7 +1962,7 @@
     "model": "mainpage.regionmedium",
     "pk": 138,
     "fields": {
-        "name": "È­Ãµ±º",
+        "name": "í™”ì²œêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1974,7 +1974,7 @@
     "model": "mainpage.regionmedium",
     "pk": 139,
     "fields": {
-        "name": "¾ç±¸±º",
+        "name": "ì–‘êµ¬êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1986,7 +1986,7 @@
     "model": "mainpage.regionmedium",
     "pk": 140,
     "fields": {
-        "name": "°í¼º±º",
+        "name": "ê³ ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -1998,7 +1998,7 @@
     "model": "mainpage.regionmedium",
     "pk": 141,
     "fields": {
-        "name": "¾ç¾ç±º",
+        "name": "ì–‘ì–‘êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2010,7 +2010,7 @@
     "model": "mainpage.regionmedium",
     "pk": 142,
     "fields": {
-        "name": "Ã»ÁÖ½Ã",
+        "name": "ì²­ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2022,7 +2022,7 @@
     "model": "mainpage.regionmedium",
     "pk": 143,
     "fields": {
-        "name": "ÃæÁÖ½Ã",
+        "name": "ì¶©ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2034,7 +2034,7 @@
     "model": "mainpage.regionmedium",
     "pk": 144,
     "fields": {
-        "name": "Á¦Ãµ½Ã",
+        "name": "ì œì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2046,7 +2046,7 @@
     "model": "mainpage.regionmedium",
     "pk": 145,
     "fields": {
-        "name": "º¸Àº±º",
+        "name": "ë³´ì€êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2058,7 +2058,7 @@
     "model": "mainpage.regionmedium",
     "pk": 146,
     "fields": {
-        "name": "¿ÁÃµ±º",
+        "name": "ì˜¥ì²œêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2070,7 +2070,7 @@
     "model": "mainpage.regionmedium",
     "pk": 147,
     "fields": {
-        "name": "¿µµ¿±º",
+        "name": "ì˜ë™êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2082,7 +2082,7 @@
     "model": "mainpage.regionmedium",
     "pk": 148,
     "fields": {
-        "name": "ÁõÆò±º",
+        "name": "ì¦í‰êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2094,7 +2094,7 @@
     "model": "mainpage.regionmedium",
     "pk": 149,
     "fields": {
-        "name": "ÁøÃµ±º",
+        "name": "ì§„ì²œêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2106,7 +2106,7 @@
     "model": "mainpage.regionmedium",
     "pk": 150,
     "fields": {
-        "name": "±«»ê±º",
+        "name": "ê´´ì‚°êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2118,7 +2118,7 @@
     "model": "mainpage.regionmedium",
     "pk": 151,
     "fields": {
-        "name": "À½¼º±º",
+        "name": "ìŒì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2130,7 +2130,7 @@
     "model": "mainpage.regionmedium",
     "pk": 152,
     "fields": {
-        "name": "´Ü¾ç±º",
+        "name": "ë‹¨ì–‘êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2142,7 +2142,7 @@
     "model": "mainpage.regionmedium",
     "pk": 153,
     "fields": {
-        "name": "Ãµ¾È½Ã",
+        "name": "ì²œì•ˆì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2154,7 +2154,7 @@
     "model": "mainpage.regionmedium",
     "pk": 154,
     "fields": {
-        "name": "°øÁÖ½Ã",
+        "name": "ê³µì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2166,7 +2166,7 @@
     "model": "mainpage.regionmedium",
     "pk": 155,
     "fields": {
-        "name": "º¸·É½Ã",
+        "name": "ë³´ë ¹ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2178,7 +2178,7 @@
     "model": "mainpage.regionmedium",
     "pk": 156,
     "fields": {
-        "name": "¾Æ»ê½Ã",
+        "name": "ì•„ì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2190,7 +2190,7 @@
     "model": "mainpage.regionmedium",
     "pk": 157,
     "fields": {
-        "name": "¼­»ê½Ã",
+        "name": "ì„œì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2202,7 +2202,7 @@
     "model": "mainpage.regionmedium",
     "pk": 158,
     "fields": {
-        "name": "³í»ê½Ã",
+        "name": "ë…¼ì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2214,7 +2214,7 @@
     "model": "mainpage.regionmedium",
     "pk": 159,
     "fields": {
-        "name": "°è·æ½Ã",
+        "name": "ê³„ë£¡ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2226,7 +2226,7 @@
     "model": "mainpage.regionmedium",
     "pk": 160,
     "fields": {
-        "name": "´çÁø½Ã",
+        "name": "ë‹¹ì§„ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2238,7 +2238,7 @@
     "model": "mainpage.regionmedium",
     "pk": 161,
     "fields": {
-        "name": "±İ»ê±º",
+        "name": "ê¸ˆì‚°êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2250,7 +2250,7 @@
     "model": "mainpage.regionmedium",
     "pk": 162,
     "fields": {
-        "name": "ºÎ¿©±º",
+        "name": "ë¶€ì—¬êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2262,7 +2262,7 @@
     "model": "mainpage.regionmedium",
     "pk": 163,
     "fields": {
-        "name": "¼­Ãµ±º",
+        "name": "ì„œì²œêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2274,7 +2274,7 @@
     "model": "mainpage.regionmedium",
     "pk": 164,
     "fields": {
-        "name": "Ã»¾ç±º",
+        "name": "ì²­ì–‘êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2286,7 +2286,7 @@
     "model": "mainpage.regionmedium",
     "pk": 165,
     "fields": {
-        "name": "È«¼º±º",
+        "name": "í™ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2298,7 +2298,7 @@
     "model": "mainpage.regionmedium",
     "pk": 166,
     "fields": {
-        "name": "¿¡»ê±º",
+        "name": "ì—ì‚°êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2310,7 +2310,7 @@
     "model": "mainpage.regionmedium",
     "pk": 167,
     "fields": {
-        "name": "ÅÂ¾È±º",
+        "name": "íƒœì•ˆêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2322,7 +2322,7 @@
     "model": "mainpage.regionmedium",
     "pk": 168,
     "fields": {
-        "name": "ÀüÁÖ½Ã",
+        "name": "ì „ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2334,7 +2334,7 @@
     "model": "mainpage.regionmedium",
     "pk": 169,
     "fields": {
-        "name": "±º»ê½Ã",
+        "name": "êµ°ì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2346,7 +2346,7 @@
     "model": "mainpage.regionmedium",
     "pk": 170,
     "fields": {
-        "name": "ÀÍ»ê½Ã",
+        "name": "ìµì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2358,7 +2358,7 @@
     "model": "mainpage.regionmedium",
     "pk": 171,
     "fields": {
-        "name": "Á¤À¾½Ã",
+        "name": "ì •ìì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2370,7 +2370,7 @@
     "model": "mainpage.regionmedium",
     "pk": 172,
     "fields": {
-        "name": "³²¿ø½Ã",
+        "name": "ë‚¨ì›ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2382,7 +2382,7 @@
     "model": "mainpage.regionmedium",
     "pk": 173,
     "fields": {
-        "name": "±èÁ¦½Ã",
+        "name": "ê¹€ì œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2394,7 +2394,7 @@
     "model": "mainpage.regionmedium",
     "pk": 174,
     "fields": {
-        "name": "¿ÏÁÖ±º",
+        "name": "ì™„ì£¼êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2406,7 +2406,7 @@
     "model": "mainpage.regionmedium",
     "pk": 175,
     "fields": {
-        "name": "Áø¾È±º",
+        "name": "ì§„ì•ˆêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2418,7 +2418,7 @@
     "model": "mainpage.regionmedium",
     "pk": 176,
     "fields": {
-        "name": "¹«ÁÖ±º",
+        "name": "ë¬´ì£¼êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2430,7 +2430,7 @@
     "model": "mainpage.regionmedium",
     "pk": 177,
     "fields": {
-        "name": "Àå¼ö±º",
+        "name": "ì¥ìˆ˜êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2442,7 +2442,7 @@
     "model": "mainpage.regionmedium",
     "pk": 178,
     "fields": {
-        "name": "ÀÓ½Ç±º",
+        "name": "ì„ì‹¤êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2454,7 +2454,7 @@
     "model": "mainpage.regionmedium",
     "pk": 179,
     "fields": {
-        "name": "¼øÃ¢±º",
+        "name": "ìˆœì°½êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2466,7 +2466,7 @@
     "model": "mainpage.regionmedium",
     "pk": 180,
     "fields": {
-        "name": "°íÃ¢±º",
+        "name": "ê³ ì°½êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2478,7 +2478,7 @@
     "model": "mainpage.regionmedium",
     "pk": 181,
     "fields": {
-        "name": "ºÎ¾È±º",
+        "name": "ë¶€ì•ˆêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2490,7 +2490,7 @@
     "model": "mainpage.regionmedium",
     "pk": 182,
     "fields": {
-        "name": "¸ñÆ÷½Ã",
+        "name": "ëª©í¬ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2502,7 +2502,7 @@
     "model": "mainpage.regionmedium",
     "pk": 183,
     "fields": {
-        "name": "¿©¼ö½Ã",
+        "name": "ì—¬ìˆ˜ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2514,7 +2514,7 @@
     "model": "mainpage.regionmedium",
     "pk": 184,
     "fields": {
-        "name": "¼øÃµ½Ã",
+        "name": "ìˆœì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2526,7 +2526,7 @@
     "model": "mainpage.regionmedium",
     "pk": 185,
     "fields": {
-        "name": "³ªÁÖ½Ã",
+        "name": "ë‚˜ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2538,7 +2538,7 @@
     "model": "mainpage.regionmedium",
     "pk": 186,
     "fields": {
-        "name": "±¤¾ç½Ã",
+        "name": "ê´‘ì–‘ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2550,7 +2550,7 @@
     "model": "mainpage.regionmedium",
     "pk": 187,
     "fields": {
-        "name": "´ã¾ç±º",
+        "name": "ë‹´ì–‘êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2562,7 +2562,7 @@
     "model": "mainpage.regionmedium",
     "pk": 188,
     "fields": {
-        "name": "°î¼º±º",
+        "name": "ê³¡ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2574,7 +2574,7 @@
     "model": "mainpage.regionmedium",
     "pk": 189,
     "fields": {
-        "name": "±¸·Ê±º",
+        "name": "êµ¬ë¡€êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2586,7 +2586,7 @@
     "model": "mainpage.regionmedium",
     "pk": 190,
     "fields": {
-        "name": "°íÈï±º",
+        "name": "ê³ í¥êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2598,7 +2598,7 @@
     "model": "mainpage.regionmedium",
     "pk": 191,
     "fields": {
-        "name": "º¸¼º±º",
+        "name": "ë³´ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2610,7 +2610,7 @@
     "model": "mainpage.regionmedium",
     "pk": 192,
     "fields": {
-        "name": "È­¼ø±º",
+        "name": "í™”ìˆœêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2622,7 +2622,7 @@
     "model": "mainpage.regionmedium",
     "pk": 193,
     "fields": {
-        "name": "ÀåÈï±º",
+        "name": "ì¥í¥êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2634,7 +2634,7 @@
     "model": "mainpage.regionmedium",
     "pk": 194,
     "fields": {
-        "name": "°­Áø±º",
+        "name": "ê°•ì§„êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2646,7 +2646,7 @@
     "model": "mainpage.regionmedium",
     "pk": 195,
     "fields": {
-        "name": "ÇØ³²±º",
+        "name": "í•´ë‚¨êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2658,7 +2658,7 @@
     "model": "mainpage.regionmedium",
     "pk": 196,
     "fields": {
-        "name": "¿µ¾Ï±º",
+        "name": "ì˜ì•”êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2670,7 +2670,7 @@
     "model": "mainpage.regionmedium",
     "pk": 197,
     "fields": {
-        "name": "¹«¾È±º",
+        "name": "ë¬´ì•ˆêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2682,7 +2682,7 @@
     "model": "mainpage.regionmedium",
     "pk": 198,
     "fields": {
-        "name": "ÇÔÆò±º",
+        "name": "í•¨í‰êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2694,7 +2694,7 @@
     "model": "mainpage.regionmedium",
     "pk": 199,
     "fields": {
-        "name": "¿µ°ü±º",
+        "name": "ì˜ê´€êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2706,7 +2706,7 @@
     "model": "mainpage.regionmedium",
     "pk": 200,
     "fields": {
-        "name": "Àå¼º±º",
+        "name": "ì¥ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2718,7 +2718,7 @@
     "model": "mainpage.regionmedium",
     "pk": 201,
     "fields": {
-        "name": "¿Ïµµ±º",
+        "name": "ì™„ë„êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2730,7 +2730,7 @@
     "model": "mainpage.regionmedium",
     "pk": 202,
     "fields": {
-        "name": "Áøµµ±º",
+        "name": "ì§„ë„êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2742,7 +2742,7 @@
     "model": "mainpage.regionmedium",
     "pk": 203,
     "fields": {
-        "name": "½Å¾È±º",
+        "name": "ì‹ ì•ˆêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2754,7 +2754,7 @@
     "model": "mainpage.regionmedium",
     "pk": 204,
     "fields": {
-        "name": "Æ÷Ç×½Ã",
+        "name": "í¬í•­ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2766,7 +2766,7 @@
     "model": "mainpage.regionmedium",
     "pk": 205,
     "fields": {
-        "name": "°æÁÖ½Ã",
+        "name": "ê²½ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2778,7 +2778,7 @@
     "model": "mainpage.regionmedium",
     "pk": 206,
     "fields": {
-        "name": "±èÃµ½Ã",
+        "name": "ê¹€ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2790,7 +2790,7 @@
     "model": "mainpage.regionmedium",
     "pk": 207,
     "fields": {
-        "name": "¾Èµ¿½Ã",
+        "name": "ì•ˆë™ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2802,7 +2802,7 @@
     "model": "mainpage.regionmedium",
     "pk": 208,
     "fields": {
-        "name": "±¸¹Ì½Ã",
+        "name": "êµ¬ë¯¸ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2814,7 +2814,7 @@
     "model": "mainpage.regionmedium",
     "pk": 209,
     "fields": {
-        "name": "¿µÁÖ½Ã",
+        "name": "ì˜ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2826,7 +2826,7 @@
     "model": "mainpage.regionmedium",
     "pk": 210,
     "fields": {
-        "name": "¿µÃµ½Ã",
+        "name": "ì˜ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2838,7 +2838,7 @@
     "model": "mainpage.regionmedium",
     "pk": 211,
     "fields": {
-        "name": "»óÁÖ½Ã",
+        "name": "ìƒì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2850,7 +2850,7 @@
     "model": "mainpage.regionmedium",
     "pk": 212,
     "fields": {
-        "name": "¹®°æ½Ã",
+        "name": "ë¬¸ê²½ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2862,7 +2862,7 @@
     "model": "mainpage.regionmedium",
     "pk": 213,
     "fields": {
-        "name": "°æ»ê½Ã",
+        "name": "ê²½ì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2874,7 +2874,7 @@
     "model": "mainpage.regionmedium",
     "pk": 214,
     "fields": {
-        "name": "±ºÀ§±º",
+        "name": "êµ°ìœ„êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2886,7 +2886,7 @@
     "model": "mainpage.regionmedium",
     "pk": 215,
     "fields": {
-        "name": "ÀÇ¼º±º",
+        "name": "ì˜ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2898,7 +2898,7 @@
     "model": "mainpage.regionmedium",
     "pk": 216,
     "fields": {
-        "name": "Ã»¼Û±º",
+        "name": "ì²­ì†¡êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2910,7 +2910,7 @@
     "model": "mainpage.regionmedium",
     "pk": 217,
     "fields": {
-        "name": "¿µ¾ç±º",
+        "name": "ì˜ì–‘êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2922,7 +2922,7 @@
     "model": "mainpage.regionmedium",
     "pk": 218,
     "fields": {
-        "name": "¿µ´ö±º",
+        "name": "ì˜ë•êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2934,7 +2934,7 @@
     "model": "mainpage.regionmedium",
     "pk": 219,
     "fields": {
-        "name": "Ã»µµ±º",
+        "name": "ì²­ë„êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2946,7 +2946,7 @@
     "model": "mainpage.regionmedium",
     "pk": 220,
     "fields": {
-        "name": "°í·É±º",
+        "name": "ê³ ë ¹êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2958,7 +2958,7 @@
     "model": "mainpage.regionmedium",
     "pk": 221,
     "fields": {
-        "name": "¼ºÁÖ±º",
+        "name": "ì„±ì£¼êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2970,7 +2970,7 @@
     "model": "mainpage.regionmedium",
     "pk": 222,
     "fields": {
-        "name": "Ä¥°î±º",
+        "name": "ì¹ ê³¡êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2982,7 +2982,7 @@
     "model": "mainpage.regionmedium",
     "pk": 223,
     "fields": {
-        "name": "¿¡Ãµ±º",
+        "name": "ì—ì²œêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -2994,7 +2994,7 @@
     "model": "mainpage.regionmedium",
     "pk": 224,
     "fields": {
-        "name": "ºÀÈ­±º",
+        "name": "ë´‰í™”êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3006,7 +3006,7 @@
     "model": "mainpage.regionmedium",
     "pk": 225,
     "fields": {
-        "name": "¿ïÁø±º",
+        "name": "ìš¸ì§„êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3018,7 +3018,7 @@
     "model": "mainpage.regionmedium",
     "pk": 226,
     "fields": {
-        "name": "¿ï¸ª±º",
+        "name": "ìš¸ë¦‰êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3030,7 +3030,7 @@
     "model": "mainpage.regionmedium",
     "pk": 227,
     "fields": {
-        "name": "Ã¢¿ø½Ã",
+        "name": "ì°½ì›ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3042,7 +3042,7 @@
     "model": "mainpage.regionmedium",
     "pk": 228,
     "fields": {
-        "name": "ÁøÁÖ½Ã",
+        "name": "ì§„ì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3054,7 +3054,7 @@
     "model": "mainpage.regionmedium",
     "pk": 229,
     "fields": {
-        "name": "Åë¿µ½Ã",
+        "name": "í†µì˜ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3066,7 +3066,7 @@
     "model": "mainpage.regionmedium",
     "pk": 230,
     "fields": {
-        "name": "»çÃµ½Ã",
+        "name": "ì‚¬ì²œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3078,7 +3078,7 @@
     "model": "mainpage.regionmedium",
     "pk": 231,
     "fields": {
-        "name": "±èÇØ½Ã",
+        "name": "ê¹€í•´ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3090,7 +3090,7 @@
     "model": "mainpage.regionmedium",
     "pk": 232,
     "fields": {
-        "name": "¹Ğ¾ç½Ã",
+        "name": "ë°€ì–‘ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3102,7 +3102,7 @@
     "model": "mainpage.regionmedium",
     "pk": 233,
     "fields": {
-        "name": "°ÅÁ¦½Ã",
+        "name": "ê±°ì œì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3114,7 +3114,7 @@
     "model": "mainpage.regionmedium",
     "pk": 234,
     "fields": {
-        "name": "¾ç»ê½Ã",
+        "name": "ì–‘ì‚°ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3126,7 +3126,7 @@
     "model": "mainpage.regionmedium",
     "pk": 235,
     "fields": {
-        "name": "ÀÇ·É±º",
+        "name": "ì˜ë ¹êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3138,7 +3138,7 @@
     "model": "mainpage.regionmedium",
     "pk": 236,
     "fields": {
-        "name": "ÇÔ¾È±º",
+        "name": "í•¨ì•ˆêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3150,7 +3150,7 @@
     "model": "mainpage.regionmedium",
     "pk": 237,
     "fields": {
-        "name": "Ã¢³ç±º",
+        "name": "ì°½ë…•êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3162,7 +3162,7 @@
     "model": "mainpage.regionmedium",
     "pk": 238,
     "fields": {
-        "name": "°í¼º±º",
+        "name": "ê³ ì„±êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3174,7 +3174,7 @@
     "model": "mainpage.regionmedium",
     "pk": 239,
     "fields": {
-        "name": "³²ÇØ±º",
+        "name": "ë‚¨í•´êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3186,7 +3186,7 @@
     "model": "mainpage.regionmedium",
     "pk": 240,
     "fields": {
-        "name": "ÇÏµ¿±º",
+        "name": "í•˜ë™êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3198,7 +3198,7 @@
     "model": "mainpage.regionmedium",
     "pk": 241,
     "fields": {
-        "name": "»êÃ»±º",
+        "name": "ì‚°ì²­êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3210,7 +3210,7 @@
     "model": "mainpage.regionmedium",
     "pk": 242,
     "fields": {
-        "name": "ÇÔ¾ç±º",
+        "name": "í•¨ì–‘êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3222,7 +3222,7 @@
     "model": "mainpage.regionmedium",
     "pk": 243,
     "fields": {
-        "name": "°ÅÃ¢±º",
+        "name": "ê±°ì°½êµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3234,7 +3234,7 @@
     "model": "mainpage.regionmedium",
     "pk": 244,
     "fields": {
-        "name": "ÇÕÃµ±º",
+        "name": "í•©ì²œêµ°",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3246,7 +3246,7 @@
     "model": "mainpage.regionmedium",
     "pk": 245,
     "fields": {
-        "name": "Á¦ÁÖ½Ã",
+        "name": "ì œì£¼ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3258,7 +3258,7 @@
     "model": "mainpage.regionmedium",
     "pk": 246,
     "fields": {
-        "name": "¼­±ÍÆ÷½Ã",
+        "name": "ì„œê·€í¬ì‹œ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -3270,7 +3270,7 @@
     "model": "mainpage.regionmedium",
     "pk": 247,
     "fields": {
-        "name": "ÀüÃ¼¼±ÅÃ",
+        "name": "ì „ì²´ì„ íƒ",
         "no_infected": 0,
         "no_deceased": 0,
         "no_offisolated": 0,
@@ -4015,7 +4015,7 @@
             "regionmedium"
         ],
         "object_id": "247",
-        "object_repr": "ÀüÃ¼¼±ÅÃ",
+        "object_repr": "ì „ì²´ì„ íƒ",
         "action_flag": 1,
         "change_message": "[{\"added\": {}}]"
     }

--- a/django_monitoring/mainpage/kakaosender.py
+++ b/django_monitoring/mainpage/kakaosender.py
@@ -1,0 +1,58 @@
+
+# 55726a505564796436337345506d44 인증
+import requests
+from bs4 import BeautifulSoup
+import time
+import json
+
+# 도구 - 메세지 템플릿 해서 템플릿 생성 후 Rest API - 메시지 에서 액세스 토큰 발급
+KAKAO_TOKEN = "s3llEZoge5LsusPXEubqI6kHafztiaeYcjcuIQopcFEAAAF2GlZblQ"
+send_lists = []
+
+def send_to_kakao(text):
+    header = {"Authorization": 'Bearer ' + KAKAO_TOKEN}
+    url = "https://kapi.kakao.com/v2/api/talk/memo/default/send"
+    post = {
+        "object_type": "text",
+        "text": text,
+        "link": {
+            "web_url": "https://developers.kakao.com",
+            "mobile_web_url": "https://developers.kakao.com"
+        },
+    }
+    data = {"template_object": json.dumps(post)}
+    return requests.post(url, headers=header, data=data)
+
+def search():
+    url2="https://www.edaily.co.kr/article/society"
+    r=requests.get(url2)
+    bs=BeautifulSoup(r.content,'lxml')
+    divs=bs.select("ul.newsbox_texts") #select의 결과는 list이다
+    for x in divs:
+        if "코로나" in str(x) and "확진" in str(x):
+            a=[]
+            a.append(str(x))
+            if count==0:
+                b.append(str(x))
+
+            if count==0:
+                for z in a:
+                    send_to_kakao(str(z))
+            if count>0:
+                for u in a:
+                    if u not in b:
+                        send_to_kakao(str(u))
+
+            if str(x) not in b:
+                b.append(str(x))
+
+if __name__== "__main__":
+    global count
+    count=0
+    a=[]
+    b=[]
+    while True:
+        print(count)
+        search()
+        count+=1
+        time.sleep(60) #1시간에 한번씩 검사해서 알림


### PR DESCRIPTION
카카오 developer 에서 제공하는 기능이

나에게 메세지 보내기, 내 친구에게 메세지 보내기 밖에 제공이 안댐..

일단  종연이가 구현한 카카오 구독에 저장한 로그인 내역이 나랑은 연동이 안되니까

시험삼아 해당 uri에서 해당 단어에 해당하면 나에게 메시지를 보내도록 작성했는데,

카카오 디벨로퍼에서

도구 - 메세지 템플릿 해서 템플릿 생성 후 Rest API - 메시지 에서 액세스 토큰 발급 한다음에 

KAKAO_TOKEN = " " 안에 값 넣어주면 밑에 Search 함수에 맞게 보내짐.


dbdump 파일 바꾼 이유는 내가 맥쓰는데 계속 인코딩 오류나서 그냥 내가 다시저장함